### PR TITLE
<App> pass productid to components

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -1,5 +1,6 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable class-methods-use-this */
 import React from 'react';
-import axios from 'axios';
 
 import Overview from './Overview/Overview.jsx';
 import RatingsAndReviews from './Ratings-And-Reviews/Ratings-And-Reviews.jsx';
@@ -10,31 +11,30 @@ class App extends React.Component {
     super(props);
 
     this.state = {
-      data: {}
-    }
+      productId: undefined,
+    };
   }
 
   componentDidMount() {
-    axios({
-      url: 'api/products/23718/styles',
-      method: 'get'
-    })
-      .then(data => {
-        this.setState({
-          data: data
-        })
-      })
-      .catch(() => console.log('failed retrieving data'));
+    const defaultId = '23718'; // A random default product
+    const productId = this.getProductIdFromUrl() ?? defaultId;
+    this.setState({ productId });
+  }
+
+  getProductIdFromUrl() {
+    const { search } = window.location;
+    const productIdRegex = /p_id=([0-9]+)/; // E.g.: "?p_id=12345"
+    return productIdRegex.exec(search)?.[1];
   }
 
   render() {
-    return (
+    return this.state.productId ? (
       <div>
-        <Overview data={this.state.data}/>
-        <Related_Items data={this.state.data}/>
-        <RatingsAndReviews data={this.state.data}/>
+        <Overview productId={this.state.productId} />
+        <Related_Items productId={this.state.productId} />
+        <RatingsAndReviews productId={this.state.productId} />
       </div>
-    );
+    ) : (<div>loading...</div>);
   }
 }
 


### PR DESCRIPTION
This will make App grab the productId from the page url's p_id parameter, and pass that value to each of our components.

I took out the api query that had been in App, which should be fine because I don't think anyone was using it anyway.

Also, as the moment, I have "loading..." render instead of the actual page for the split second while App is grabbing the product id. Maybe "loading..." isn't ideal, but I did find that it was better not to render our components until the productId prop was available. This behavior isn't written in stone, though.